### PR TITLE
Fix: Update package.json to Remove Illegal Characters from Name Field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Build it",
+  "name": "build-it",
   "version": "1.0.0",
   "description": "Your Figma widget",
   "scripts": {


### PR DESCRIPTION
#### Overview
This PR addresses an issue in the `package.json` file where the `name` field contained illegal characters. According to the npm and Node.js naming conventions, package names should not contain spaces or uppercase letters. The previous package name `"Build it"` violates these conventions.

#### Changes
- **File Modified**: `package.json`
- **Key Changes**:
  - **Before**: `"name": "Build it"`
  - **After**: `"name": "build-it"`
