### PR TITLE
Add history and chat prompt

### DIFF
--- a/ui.html
+++ b/ui.html
@@ -1,4 +1,53 @@
 <script>
+
+  /**
+   * Unsecured fallback for copying text to clipboard
+   * @param text - The text to be copied to the clipboard
+   */
+  function unsecuredCopyToClipboard(text) {
+    // Create a textarea element
+    const textArea = document.createElement('textarea');
+    textArea.value = text;
+    document.body.appendChild(textArea);
+
+    // Focus and select the textarea content
+    textArea.focus();
+    textArea.select();
+
+    // Attempt to copy the text to the clipboard
+    try {
+      document.execCommand('copy');
+    } catch (e) {
+      logger.error('Unable to copy content to clipboard!', e);
+    }
+
+    // Remove the textarea element from the DOM
+    document.body.removeChild(textArea);
+  }
+
+  /**
+   * Copies the text passed as param to the system clipboard
+   * Check if using HTTPS and navigator.clipboard is available
+   * Then uses standard clipboard API, otherwise uses fallback
+   *
+   * Inspired by: https://stackoverflow.com/questions/71873824/copy-text-to-clipboard-cannot-read-properties-of-undefined-reading-writetext
+   * and https://forum.figma.com/t/write-to-clipboard-from-custom-plugin/11860/12
+   *
+   * @param content - The content to be copied to the clipboard
+   */
+  function copyToClipboard(content) {
+    // If the context is secure and clipboard API is available, use it
+    if (
+      window.isSecureContext &&
+      typeof navigator?.clipboard?.writeText === 'function'
+    ) {
+      navigator.clipboard.writeText(content);
+    }
+    // Otherwise, use the unsecured fallback
+    else {
+      unsecuredCopyToClipboard(content);
+    }
+  }
   onmessage = function (e) {
     let message = e.data.pluginMessage;
 
@@ -7,6 +56,11 @@
       document.open();
       document.write(html);
       document.close();
+    }
+    console.log(message.type)
+    if (message.type == "copy") {
+      let text = message.text;
+      copyToClipboard(text);
     }
   };
 </script>


### PR DESCRIPTION
Hi, first of all great work!

I've adjusted on you work slighly the widget and introduced

1. A history of responses in terms of HTML
2. These are included in the chat history to OpenAI with some inclusions similar to TLDraw
3. The possibility of adding a prompt as well which is apended as part of the communication
4. Re-Opening of preview
5. Clear history
6. Copy to clipboard when clicking any of the previous messages

<img width="385" alt="image" src="https://github.com/jordansinger/build-it-figma-ai/assets/2339134/359dd3d9-fad3-40dc-9023-40396eb681b2">
